### PR TITLE
Enabling preemptive authentication

### DIFF
--- a/src/main/java/com/ontometrics/integrations/sources/AuthenticatedHttpStreamProvider.java
+++ b/src/main/java/com/ontometrics/integrations/sources/AuthenticatedHttpStreamProvider.java
@@ -1,6 +1,7 @@
 package com.ontometrics.integrations.sources;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.ResponseHandler;
@@ -36,8 +37,9 @@ public class AuthenticatedHttpStreamProvider implements StreamProvider {
             (final String login, final String password) {
         return new AuthenticatedHttpStreamProvider( new Authenticator() {
                 @Override
-                public Request authenticate(Executor httpExecutor, Request request) {
+                public Request authenticate(URL resourceUrl, Executor httpExecutor, Request request) {
                     httpExecutor.auth(login,password);
+                    httpExecutor.authPreemptive(new HttpHost(resourceUrl.getHost(), resourceUrl.getPort(), resourceUrl.getProtocol()));
                     return request;
                 }
             }
@@ -56,7 +58,7 @@ public class AuthenticatedHttpStreamProvider implements StreamProvider {
     @Override
     public <RES> RES openResourceStream(URL resourceUrl, final InputStreamHandler<RES> inputStreamHandler) throws Exception {
         Request request = Request.Get(resourceUrl.toExternalForm());
-        request = this.authenticator.authenticate(httpExecutor, request);
+        request = this.authenticator.authenticate(resourceUrl, httpExecutor, request);
         return httpExecutor.execute(request)
                 .handleResponse(
                     new ResponseHandler<RES>() {

--- a/src/main/java/com/ontometrics/integrations/sources/Authenticator.java
+++ b/src/main/java/com/ontometrics/integrations/sources/Authenticator.java
@@ -3,9 +3,11 @@ package com.ontometrics.integrations.sources;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 
+import java.net.URL;
+
 /**
  * Authenticates request issued by {@link com.ontometrics.integrations.sources.SourceEventMapper}
  */
 public interface Authenticator {
-    Request authenticate(Executor httpExecutor, Request request);
+    Request authenticate(URL resourceUrl, Executor httpExecutor, Request request);
 }

--- a/src/main/java/com/ontometrics/integrations/sources/HubAuthenticator.java
+++ b/src/main/java/com/ontometrics/integrations/sources/HubAuthenticator.java
@@ -8,6 +8,8 @@ import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.joda.time.DateTime;
 
+import java.net.URL;
+
 
 /**
  * This use Hub Client Credentials OAuth
@@ -32,7 +34,7 @@ public class HubAuthenticator implements Authenticator {
     }
 
     @Override
-    public Request authenticate(Executor httpExecutor, Request request) {
+    public Request authenticate(URL resourceUrl, Executor httpExecutor, Request request) {
         if (accessToken == null || isExpired(accessToken)) {
             accessToken = resolveAccessToken();
         }


### PR DESCRIPTION
This change forces to send credentials when accessing the instance, because YouTrack doesn't explicitly challenges client to do the auth.

This closes ontometrics/slack-youtrack#15
